### PR TITLE
fix(identity): close permission bypass on user Get/Find APIs

### DIFF
--- a/modules/identity/src/Passingwind.Abp.Identity.Application/IdentityUserV2AppService.cs
+++ b/modules/identity/src/Passingwind.Abp.Identity.Application/IdentityUserV2AppService.cs
@@ -268,6 +268,8 @@ public class IdentityUserV2AppService : IdentityUserAppService, IIdentityUserV2A
         (await UserManager.SetTwoFactorEnabledAsync(entity, input.Enabled)).CheckErrors();
     }
 
+    // Must use method-level [Authorize]: ABP skips class-level Authorize on non-public (explicit interface) methods.
+    [Authorize(IdentityPermissions.Users.Default)]
     async Task<IdentityUserV2Dto?> IIdentityUserV2AppService.FindByUsernameAsync(string userName)
     {
         var entity = await UserManager.FindByNameAsync(userName);
@@ -277,6 +279,7 @@ public class IdentityUserV2AppService : IdentityUserAppService, IIdentityUserV2A
         return ObjectMapper.Map<IdentityUser, IdentityUserV2Dto>(entity);
     }
 
+    [Authorize(IdentityPermissions.Users.Default)]
     async Task<IdentityUserV2Dto?> IIdentityUserV2AppService.FindByEmailAsync(string email)
     {
         var entity = await UserManager.FindByEmailAsync(email);
@@ -286,6 +289,7 @@ public class IdentityUserV2AppService : IdentityUserAppService, IIdentityUserV2A
         return ObjectMapper.Map<IdentityUser, IdentityUserV2Dto>(entity);
     }
 
+    [Authorize(IdentityPermissions.Users.Default)]
     async Task<IdentityUserV2Dto> IReadOnlyAppService<IdentityUserV2Dto, IdentityUserV2Dto, Guid, IdentityUserPagedListRequestDto>.GetAsync(Guid id)
     {
         return ObjectMapper.Map<IdentityUser, IdentityUserV2Dto>(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`IdentityUserV2AppService` implements `GetAsync`, `FindByUsernameAsync`, and `FindByEmailAsync` via **explicit interface members** (required because the base `IdentityUserAppService` already exposes public methods with the same names but `IdentityUserDto` return types).

ABP's `MethodInvocationAuthorizationService` only merges **class-level** `[Authorize]` for `IsPublic` methods. Explicit interface implementations are non-public, so class-level `[Authorize(IdentityPermissions.Users.Default)]` was skipped and these endpoints effectively had **no permission check**:

- `GET /api/identity/users/{id}`
- `GET /api/identity/users/by-username/{userName}`
- `GET /api/identity/users/by-email/{email}`

## Fix

Keep the explicit implementations (return-type conflict with base), and add method-level `[Authorize(IdentityPermissions.Users.Default)]` on each. Method-level attributes are still read regardless of `IsPublic`.

## Scope

A scan of other module AppServices found no additional explicit-interface authorization bypasses.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b1149a1-6562-489b-aecb-841c97d5c84f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b1149a1-6562-489b-aecb-841c97d5c84f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

