### PR TITLE
ci: auto-follow ABP MINOR/MAJOR and open PR

### DIFF
--- a/.github/workflows/abp-version-bump.yml
+++ b/.github/workflows/abp-version-bump.yml
@@ -1,0 +1,119 @@
+name: abp version bump
+
+on:
+  schedule:
+    # Every Monday at 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: abp-version-bump
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect ABP MINOR/MAJOR update
+        id: detect
+        run: |
+          set -euo pipefail
+          OUTPUT="$(./scripts/abp-version-bump.sh --dry-run)"
+          echo "$OUTPUT"
+          # Only KEY=VALUE lines for GITHUB_OUTPUT
+          echo "$OUTPUT" | grep -E '^[A-Z_]+=.' >> "$GITHUB_OUTPUT"
+
+          HAS_UPDATE="$(echo "$OUTPUT" | awk -F= '/^HAS_UPDATE=/{print $2; exit}')"
+          if [[ "$HAS_UPDATE" != "true" ]]; then
+            echo "No ABP MINOR/MAJOR update available."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip if branch or PR already exists
+        id: existing
+        if: steps.detect.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.detect.outputs.BRANCH }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Remote branch ${BRANCH} already exists; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if gh pr list --state open --head "$BRANCH" --json number --jq 'length' | grep -qv '^0$'; then
+            echo "Open PR for ${BRANCH} already exists; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Apply version bump
+        if: steps.detect.outputs.skip != 'true' && steps.existing.outputs.skip != 'true'
+        run: ./scripts/abp-version-bump.sh
+
+      - name: Create pull request
+        if: steps.detect.outputs.skip != 'true' && steps.existing.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.detect.outputs.BRANCH }}
+          CURRENT_ABP: ${{ steps.detect.outputs.CURRENT_ABP }}
+          TARGET_ABP: ${{ steps.detect.outputs.TARGET_ABP }}
+          CURRENT_MODULE_VERSION: ${{ steps.detect.outputs.CURRENT_MODULE_VERSION }}
+          NEW_MODULE_VERSION: ${{ steps.detect.outputs.NEW_MODULE_VERSION }}
+          BUMP_KIND: ${{ steps.detect.outputs.BUMP_KIND }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+          git add common.props host/common.props
+          git commit -m "chore: bump ABP to ${TARGET_ABP} and module to ${NEW_MODULE_VERSION}"
+          git push -u origin "$BRANCH"
+
+          MAJOR_NOTE=""
+          if [[ "$BUMP_KIND" == "major" ]]; then
+            MAJOR_NOTE=$'\n> **Major upgrade:** review TFM (`Tfw`), `MicrosoftPackageVersion`, and breaking ABP API changes before merge.\n'
+          fi
+
+          BODY="$(cat <<EOF
+          ## ABP ${BUMP_KIND} version bump
+
+          | | From | To |
+          |---|---|---|
+          | ABP (\`AbpVersion\`) | \`${CURRENT_ABP}\` | \`${TARGET_ABP}\` |
+          | Module (\`ModuleVersion\`) | \`${CURRENT_MODULE_VERSION}\` | \`${NEW_MODULE_VERSION}\` |
+
+          - Branch: \`${BRANCH}\`
+          - Patch-only ABP updates are ignored by this automation.
+          - Host wildcard updated to \`${TARGET_ABP%.*}.*\` in \`host/common.props\`.
+          ${MAJOR_NOTE}
+          After merge, publish NuGet packages via **build and pack** (\`workflow_dispatch\` with NuGet push enabled).
+
+          ---
+          *Opened by \`.github/workflows/abp-version-bump.yml\`*
+          EOF
+          )"
+
+          # Trim leading indentation from heredoc
+          BODY="$(printf '%s\n' "$BODY" | sed 's/^          //')"
+
+          gh pr create \
+            --base "${{ github.event.repository.default_branch }}" \
+            --head "$BRANCH" \
+            --title "chore: bump ABP to ${TARGET_ABP} (module ${NEW_MODULE_VERSION})" \
+            --body "$BODY"

--- a/scripts/abp-version-bump.sh
+++ b/scripts/abp-version-bump.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Detect a newer ABP MINOR or MAJOR on NuGet and bump project versions.
+# Ignores PATCH-only updates. Writes common.props + host/common.props when applying.
+#
+# Usage:
+#   ./scripts/abp-version-bump.sh              # detect + apply
+#   ./scripts/abp-version-bump.sh --dry-run    # detect only, no file writes
+#   ./scripts/abp-version-bump.sh --check      # exit 0 if update available, 1 if not
+#
+# On apply/dry-run with an update, prints KEY=VALUE lines for CI:
+#   HAS_UPDATE, CURRENT_ABP, TARGET_ABP, BRANCH, CURRENT_MODULE_VERSION,
+#   NEW_MODULE_VERSION, BUMP_KIND (minor|major)
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMMON_PROPS="${ROOT_DIR}/common.props"
+HOST_COMMON_PROPS="${ROOT_DIR}/host/common.props"
+NUGET_INDEX_URL="https://api.nuget.org/v3-flatcontainer/volo.abp.core/index.json"
+
+DRY_RUN=0
+CHECK_ONLY=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --check) CHECK_ONLY=1 ;;
+    -h|--help)
+      sed -n '2,16p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -f "$COMMON_PROPS" ]]; then
+  echo "Missing ${COMMON_PROPS}" >&2
+  exit 1
+fi
+
+if [[ ! -f "$HOST_COMMON_PROPS" ]]; then
+  echo "Missing ${HOST_COMMON_PROPS}" >&2
+  exit 1
+fi
+
+read_prop() {
+  local file="$1"
+  local name="$2"
+  local value
+  value="$(grep -oE "<${name}>[^<]+</${name}>" "$file" | head -n1 | sed -E "s|</?${name}>||g")"
+  if [[ -z "$value" ]]; then
+    echo "Property ${name} not found in ${file}" >&2
+    exit 1
+  fi
+  printf '%s' "$value"
+}
+
+CURRENT_ABP="$(read_prop "$COMMON_PROPS" AbpVersion)"
+CURRENT_MODULE="$(read_prop "$COMMON_PROPS" ModuleVersion)"
+
+# Strip any floating range / wildcard for comparison (e.g. 9.0.*)
+CURRENT_ABP_BASE="${CURRENT_ABP%%\**}"
+CURRENT_ABP_BASE="${CURRENT_ABP_BASE%.}"
+
+parse_semver() {
+  # stdin: version string -> stdout: major minor patch (integers); fails on prerelease
+  python3 - "$1" <<'PY'
+import re, sys
+v = sys.argv[1].strip()
+# reject prerelease / build metadata for "current" parse of project props? allow plain x.y.z
+m = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", v)
+if not m:
+    # allow major.minor only
+    m = re.fullmatch(r"(\d+)\.(\d+)", v)
+    if not m:
+        print(f"unsupported version: {v}", file=sys.stderr)
+        sys.exit(1)
+    print(m.group(1), m.group(2), 0)
+else:
+    print(m.group(1), m.group(2), m.group(3))
+PY
+}
+
+read -r CUR_MAJOR CUR_MINOR CUR_PATCH <<<"$(parse_semver "$CURRENT_ABP_BASE")"
+read -r MOD_MAJOR MOD_MINOR MOD_PATCH <<<"$(parse_semver "$CURRENT_MODULE")"
+
+TMP_JSON="$(mktemp)"
+trap 'rm -f "$TMP_JSON"' EXIT
+
+curl -fsSL "$NUGET_INDEX_URL" -o "$TMP_JSON"
+
+TARGET_INFO="$(
+  python3 - "$TMP_JSON" "$CUR_MAJOR" "$CUR_MINOR" <<'PY'
+import json, re, sys
+
+path, cur_major, cur_minor = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+with open(path, encoding="utf-8") as f:
+    versions = json.load(f)["versions"]
+
+stable = []
+for v in versions:
+    # SemVer core only: no -rc / -preview / +build
+    if re.fullmatch(r"\d+\.\d+\.\d+", v):
+        maj, mino, pat = map(int, v.split("."))
+        stable.append((maj, mino, pat, v))
+
+if not stable:
+    print("no stable versions found", file=sys.stderr)
+    sys.exit(1)
+
+# highest (major, minor), then highest patch on that line
+stable.sort()
+best_line = max((maj, mino) for maj, mino, _, _ in stable)
+line_versions = [t for t in stable if (t[0], t[1]) == best_line]
+target = max(line_versions, key=lambda t: t[2])
+t_maj, t_min, t_pat, t_ver = target
+
+if (t_maj, t_min) <= (cur_major, cur_minor):
+    print("NONE")
+    sys.exit(0)
+
+if t_maj > cur_major:
+    kind = "major"
+elif t_min > cur_minor:
+    kind = "minor"
+else:
+    kind = "none"
+
+print(f"{t_ver}|{t_maj}|{t_min}|{t_pat}|{kind}")
+PY
+)"
+
+if [[ "$TARGET_INFO" == "NONE" ]]; then
+  if [[ "$CHECK_ONLY" -eq 1 ]]; then
+    exit 1
+  fi
+  echo "HAS_UPDATE=false"
+  echo "CURRENT_ABP=${CURRENT_ABP}"
+  echo "CURRENT_MODULE_VERSION=${CURRENT_MODULE}"
+  echo "No ABP MINOR/MAJOR update available (current ${CURRENT_ABP})." >&2
+  exit 0
+fi
+
+IFS='|' read -r TARGET_ABP T_MAJOR T_MINOR T_PATCH BUMP_KIND <<<"$TARGET_INFO"
+BRANCH="abp/${T_MAJOR}.${T_MINOR}.x"
+
+if [[ "$BUMP_KIND" == "major" ]]; then
+  NEW_MODULE="$((MOD_MAJOR + 1)).0.0"
+elif [[ "$BUMP_KIND" == "minor" ]]; then
+  NEW_MODULE="${MOD_MAJOR}.$((MOD_MINOR + 1)).0"
+else
+  echo "Unexpected bump kind: ${BUMP_KIND}" >&2
+  exit 1
+fi
+
+if [[ "$CHECK_ONLY" -eq 1 ]]; then
+  exit 0
+fi
+
+echo "HAS_UPDATE=true"
+echo "CURRENT_ABP=${CURRENT_ABP}"
+echo "TARGET_ABP=${TARGET_ABP}"
+echo "BRANCH=${BRANCH}"
+echo "CURRENT_MODULE_VERSION=${CURRENT_MODULE}"
+echo "NEW_MODULE_VERSION=${NEW_MODULE}"
+echo "BUMP_KIND=${BUMP_KIND}"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "Dry run: would set AbpVersion=${TARGET_ABP}, ModuleVersion=${NEW_MODULE}, host AbpVersion=${T_MAJOR}.${T_MINOR}.*" >&2
+  exit 0
+fi
+
+# Update root common.props
+python3 - "$COMMON_PROPS" "$TARGET_ABP" "$NEW_MODULE" <<'PY'
+from pathlib import Path
+import re, sys
+path, abp, mod = Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+text = path.read_text(encoding="utf-8")
+text2, n1 = re.subn(r"(<AbpVersion>)[^<]+(</AbpVersion>)", rf"\g<1>{abp}\2", text, count=1)
+text3, n2 = re.subn(r"(<ModuleVersion>)[^<]+(</ModuleVersion>)", rf"\g<1>{mod}\2", text2, count=1)
+if n1 != 1 or n2 != 1:
+    raise SystemExit(f"failed to update common.props (AbpVersion={n1}, ModuleVersion={n2})")
+path.write_text(text3, encoding="utf-8")
+PY
+
+# Update host wildcard AbpVersion (first AbpVersion in host/common.props)
+python3 - "$HOST_COMMON_PROPS" "${T_MAJOR}.${T_MINOR}.*" <<'PY'
+from pathlib import Path
+import re, sys
+path, abp = Path(sys.argv[1]), sys.argv[2]
+text = path.read_text(encoding="utf-8")
+text2, n = re.subn(r"(<AbpVersion>)[^<]+(</AbpVersion>)", rf"\g<1>{abp}\2", text, count=1)
+if n != 1:
+    raise SystemExit(f"failed to update host/common.props AbpVersion (count={n})")
+path.write_text(text2, encoding="utf-8")
+PY
+
+echo "Updated ${COMMON_PROPS} and ${HOST_COMMON_PROPS}." >&2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add automation to follow ABP stable **MINOR** and **MAJOR** releases (ignore PATCH), bump this repo’s versions, and open a PR.

### Added
- [`scripts/abp-version-bump.sh`](scripts/abp-version-bump.sh) — queries NuGet `Volo.Abp.Core`, compares `(major, minor)`, updates:
  - `common.props` → `AbpVersion` + `ModuleVersion`
  - `host/common.props` → `AbpVersion` wildcard `{M}.{m}.*`
- [`.github/workflows/abp-version-bump.yml`](.github/workflows/abp-version-bump.yml) — weekly schedule (Monday 06:00 UTC) + `workflow_dispatch`

### Version rules
| ABP change | ModuleVersion |
|---|---|
| MINOR | minor +1 (e.g. `1.6.4` → `1.7.0`) |
| MAJOR | major +1 (e.g. `1.6.4` → `2.0.0`) |
| PATCH only | ignored |

PR branch format: `abp/{major}.{minor}.x` (e.g. `abp/10.5.x`). Skips if that branch or an open PR already exists.

Does **not** auto-publish NuGet; merge then use existing **build and pack** `workflow_dispatch`.

### Local check
```bash
./scripts/abp-version-bump.sh --dry-run
```

Verified dry-run against current NuGet: `9.0.5` → `10.5.0` (`BUMP_KIND=major`, branch `abp/10.5.x`, module `1.6.4` → `2.0.0`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-331a1d56-bb68-4d42-83a8-1b308d31abc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-331a1d56-bb68-4d42-83a8-1b308d31abc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

